### PR TITLE
Remove legacy sketchpad code.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+### 0.5.5
+(release pending)
+
+- @tvararu: Remove legacy sketchpad code from `patterns/lfa-components/js/views/chapter.js`.
+
 ### 0.5.4
 (released 23/06/2014)
 

--- a/patterns/lfa-components/js/views/chapter.js
+++ b/patterns/lfa-components/js/views/chapter.js
@@ -7,10 +7,8 @@ define([
   'nlform',
   'templates',
   'fluidbox',
-  'raphael',
-  'sketchpad',
   'prefetcher',
-], function($, _, Backbone, Bootstrap, Stacktable, NLForm, Templates, Fluidbox, Raphael, Sketchpad, Prefetcher) {
+], function($, _, Backbone, Bootstrap, Stacktable, NLForm, Templates, Fluidbox, Prefetcher) {
   'use strict';
 
   var ChapterView = Backbone.View.extend({
@@ -22,7 +20,7 @@ define([
     render: function(chapter) {
       var tocUrlOrder = window.App.tocUrlOrder;
 
-      if (!Templates.templateExists(chapter)) { 
+      if (!Templates.templateExists(chapter)) {
         chapter = tocUrlOrder[0]; // In lack of a 404
       }
 
@@ -137,78 +135,6 @@ define([
 
       // Enable lightboxes.
       this.$('a.lightbox').fluidbox();
-
-      // Enable sketchpads.
-      $('.sketchpad').each(function(index, sketch) {
-        var $sketch = $(sketch);
-        var $editor = $sketch.find('.editor');
-
-        var width = $sketch.data('width') || $editor.parent().width();
-        var height = $sketch.data('height') || width;
-        var primaryColor = $sketch.data('primary-color');
-        var secondaryColor = $sketch.data('secondary-color');
-        var backgroundColor = $sketch.data('background-color');
-
-        var paper = new Raphael($editor[0], width, height);
-        var sketchpad = Raphael.sketchpad(paper);
-        sketchpad.pen().color(primaryColor);
-
-        $editor.children('svg').css('background-color', backgroundColor);
-
-        var $colorSwitcher = $sketch.find('.btn-color-switcher');
-        var $eraser = $sketch.find('.btn-eraser');
-        var $undo = $sketch.find('.btn-undo');
-        var $redo = $sketch.find('.btn-redo');
-        var $destroy = $sketch.find('.btn-destroy');
-        var $save = $sketch.find('.btn-save');
-
-        $colorSwitcher.on('click', function() {
-          $eraser.removeClass('active');
-          sketchpad.pen().width(5);
-
-          if ($(this).hasClass('active')) {
-            sketchpad.pen().color(primaryColor);
-            $(this).css('color', primaryColor);
-            $(this).removeClass('active');
-          } else {
-            sketchpad.pen().color(secondaryColor);
-            $(this).css('color', secondaryColor);
-            $(this).addClass('active');
-          }
-        });
-
-        $eraser.on('click', function() {
-          if ($(this).hasClass('active')) {
-            sketchpad.pen().width(5);
-            if ($colorSwitcher.hasClass('active')) {
-              sketchpad.pen().color(secondaryColor);
-            } else {
-              sketchpad.pen().color(primaryColor);
-            }
-            $(this).removeClass('active');
-          } else {
-            sketchpad.pen().color(backgroundColor);
-            sketchpad.pen().width(25);
-            $(this).addClass('active');
-          }
-        });
-
-        $undo.on('click', function() {
-          sketchpad.undo();
-        });
-
-        $redo.on('click', function() {
-          sketchpad.redo();
-        });
-
-        $destroy.on('click', function() {
-          sketchpad.clear();
-        });
-
-        $save.on('click', function() {
-          console.log(sketchpad.json());
-        });
-      });
     }
   });
 


### PR DESCRIPTION
This code is no longer necessary, as `drawingpad` succeeds `sketchpad`.
